### PR TITLE
Fix: Restrict Instance Types for Karpenter to Avoid Incompatible ARM Instances

### DIFF
--- a/aws/karpenter-crs/Chart.yaml
+++ b/aws/karpenter-crs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: karpenter-crs
 description: Karpenter custom resources
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/aws/karpenter-crs/templates/app-nodepools.yaml
+++ b/aws/karpenter-crs/templates/app-nodepools.yaml
@@ -19,6 +19,14 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["spot", "on-demand"]
+        - key: karpenter.k8s.aws/instance-cpu-manufacturer
+          operator: In
+          values:
+            - aws
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values:
+            - '5' # skip A1 that is incompatible with AL2023
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass
@@ -54,6 +62,12 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["spot", "on-demand"]
+        - key: karpenter.k8s.aws/instance-cpu-manufacturer
+          operator: In
+          values: ["intel", "amd"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["5"]  # Skips old t2/m4/c4, ensures m5+, c5+, t3+, etc.
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass

--- a/aws/karpenter-crs/templates/base-node-pool.yaml
+++ b/aws/karpenter-crs/templates/base-node-pool.yaml
@@ -25,6 +25,14 @@ spec:
         - key: "karpenter.k8s.aws/instance-memory"
           operator: Gt
           values: ["2000"]
+        - key: karpenter.k8s.aws/instance-cpu-manufacturer
+          operator: In
+          values:
+            - aws
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values:
+            - '5' # skip A1 that is incompatible with AL2023
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass


### PR DESCRIPTION
# 🛠️ Fix: Restrict Instance Types for Karpenter to Avoid Incompatible ARM Instances

## **Context**
While using the AWS charts, including the Karpenter CRD chart, we encountered an issue with an ARM node that was spun up. The node failed with the following error log:

```
Fatal glibc error: This version of Amazon Linux requires a newer ARM64 processor compliant with at least ARM architecture 8.2-a with Cryptographic extensions. On EC2 this is Graviton 2 or later.
```

The root cause of this issue is that we are using the `AL2023` family, which no longer supports older ARM instance types (e.g., `a1.*`). However, our current filter configuration allowed these older instance types to be selected, leading to the error.

## **Proposed Solution**
To address this issue and ensure compatibility, I have added two additional filters to restrict the instance types that can be spun up by Karpenter:

1. **Manufacturer Filter**: Only allow instances manufactured by Intel or AWS (Graviton).
2. **Generation Filter**: Restrict to instance generations `5+` to ensure compatibility with newer ARM processors.

These filters will prevent older, unsupported ARM instance types from being selected.

## **Trade-offs**
- **Downside**: By adding these restrictions, the pool of available instances is reduced. This could increase the likelihood of not securing a spot instance during high-demand periods.
- **Upside**: The newer instance types (e.g., Graviton 2 or later) offer better performance and are fully compatible with `AL2023`. This ensures stability and avoids runtime errors like the one described above.

